### PR TITLE
J'ai retiré le bouton "Imprimer Tous" et sa fonctionnalité de la page…

### DIFF
--- a/templates/Prepacommande/commandes_en_preparation.html
+++ b/templates/Prepacommande/commandes_en_preparation.html
@@ -13,12 +13,6 @@
             </h1>
             <p style="color: var(--preparation-border-accent);">Liste des commandes en cours de préparation</p>
         </div>
-        <div class="flex gap-3 mt-4 md:mt-0">
-            <button onclick="imprimerTousLesTickets()" class="inline-flex items-center px-4 py-2 bg-green-600 hover:bg-green-700 text-white text-sm font-medium rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500 transition-colors">
-                <i class="fas fa-print mr-2"></i>
-                Imprimer Tous
-            </button>
-        </div>
     </div>
 
     <div class="bg-white rounded-xl shadow-lg border p-6 mb-8" style="border-color: var(--preparation-border-accent);">
@@ -172,17 +166,6 @@ function imprimerTicketsSelectionnes() {
     window.open(url, '_blank');
 }
 
-function imprimerTousLesTickets() {
-    const commandeIds = [{% for commande in commandes %}{{ commande.pk }}{% if not forloop.last %},{% endif %}{% endfor %}];
-    
-    if (commandeIds.length === 0) {
-        alert('Aucune commande à imprimer.');
-        return;
-    }
-    
-    const url = "{% url 'Prepacommande:imprimer_tickets_preparation' %}?ids=" + commandeIds.join(',');
-    window.open(url, '_blank');
-}
 
 // Initialiser les boutons au chargement de la page
 document.addEventListener('DOMContentLoaded', function() {


### PR DESCRIPTION
… commandes_en_preparation.html

1. Suppression du bouton dans l'en-tête : ✅ Retiré le bouton "Imprimer Tous" de la section en-tête ✅ Supprimé la div conteneur avec les classes flex
2. Suppression de la fonction JavaScript : ✅ Retiré la fonction imprimerTousLesTickets() complète ✅ Supprimé le code qui générait la liste des IDs de commandes �� Résultat :
La page conserve maintenant uniquement :
✅ Impression individuelle : Bouton "Ticket" pour chaque commande ✅ Impression sélectionnée : Bouton "Imprimer Sélection" pour les commandes cochées ✅ Fonctionnalités de sélection : Cases à cocher et sélection multiple Le bouton "Imprimer Tous" a été complètement retiré car il n'est plus nécessaire dans ce projet. L'interface est maintenant plus épurée et se concentre sur les fonctionnalités d'impression ciblées.