### PR TITLE
Ajout état annulation, maj ticket total et texte accueil (YZ RESCUE)

### DIFF
--- a/operatConfirme/views.py
+++ b/operatConfirme/views.py
@@ -1410,7 +1410,7 @@ def annuler_commande_confirmation(request, commande_id):
                 })
             
             # Autoriser l'annulation depuis "En cours de confirmation" ou "Affectée"
-            etats_autorises = ['en cours de confirmation', 'affectée']
+            etats_autorises = ['en cours de confirmation', 'affectée','report de confirmation']
             if etat_actuel.enum_etat.libelle.lower() not in etats_autorises:
                 return JsonResponse({
                     'success': False,

--- a/templates/Superpreparation/partials/_ticket_commande_new.html
+++ b/templates/Superpreparation/partials/_ticket_commande_new.html
@@ -636,7 +636,6 @@
                     <i class="fas fa-calculator total-icon"></i>
                     {{ commande.total }} DH
                     {% if commande.frais_livraison %}
-                        <span style="font-size: 7pt; color: #666;">(frais inclus)</span>
                     {% endif %}
                 </div>
             </div>

--- a/templates/login/login.html
+++ b/templates/login/login.html
@@ -363,7 +363,7 @@
             </div>
             <div class="banner">
                 <div class="banner-content">
-                    <h1 class="wel_text">Bienvenue <br /> COD RESCUE</h1>
+                    <h1 class="wel_text">Bienvenue <br /> YZ RESCUE</h1>
                     <p class="para">Votre plateforme de gestion des commandes intelligente et efficace.</p>
                     <div style="display: flex; justify-content: center; margin-top: 1rem;">
                         <div class="logo-ring" style="display: inline-block; padding: 12px 14px; border-radius: 20px; background: rgba(255,255,255,0.08); backdrop-filter: blur(4px); border: 1px solid rgba(255,255,255,0.25); box-shadow: 0 12px 32px rgba(0,0,0,0.35), inset 0 0 0 6px rgba(255,255,255,0.06);">


### PR DESCRIPTION
Ajout de l’état "report de confirmation" à la liste des statuts autorisés pour l’annulation de commande dans annuler_commande_confirmation. Suppression du libellé "(frais inclus)" du total de commande dans le partial du ticket. Mise à jour du texte de bienvenue sur la page de connexion, remplacé de "COD RESCUE" par "YZ RESCUE".