### PR TITLE
Ajoute gestion des articles retournés au module Service

### DIFF
--- a/Superpreparation/service_views.py
+++ b/Superpreparation/service_views.py
@@ -1,0 +1,378 @@
+"""
+Vues pour la gestion des services (articles retournés) dans Superpreparation
+Adaptation des vues de operatLogistic/articles_retournes_views.py
+"""
+
+from django.shortcuts import render, redirect, get_object_or_404
+from django.contrib.auth.decorators import login_required
+from django.contrib import messages
+from django.http import JsonResponse
+from django.views.decorators.http import require_POST
+from django.db.models import Q, Sum, Count
+from django.core.paginator import Paginator
+from django.utils import timezone
+
+from parametre.models import Operateur
+from commande.models import Commande, ArticleRetourne
+from .decorators import superviseur_preparation_required
+
+
+@superviseur_preparation_required
+def liste_articles_retournes_service(request):
+    """Liste des articles retournés en attente de traitement - Version Superpreparation"""
+   
+
+    # Récupérer les articles retournés avec préfetch des relations
+    articles_retournes = ArticleRetourne.objects.select_related(
+        'commande', 'article', 'variante', 'operateur_retour'
+    ).prefetch_related(
+        'variante__couleur', 'variante__pointure'
+    ).order_by('-date_retour')
+
+    # Filtre par statut
+    statut_filter = request.GET.get('statut', 'en_attente')
+    if statut_filter and statut_filter != 'tous':
+        articles_retournes = articles_retournes.filter(statut_retour=statut_filter)
+
+    # Filtre par recherche
+    search_query = request.GET.get('search', '')
+    if search_query:
+        articles_retournes = articles_retournes.filter(
+            Q(commande__id_yz__icontains=search_query) |
+            Q(article__nom__icontains=search_query) |
+            Q(commande__client__nom__icontains=search_query) |
+            Q(commande__client__prenom__icontains=search_query)
+        )
+
+    # Statistiques pour le tableau de bord
+    stats = {
+        'total_en_attente': ArticleRetourne.objects.filter(statut_retour='en_attente').count(),
+        'total_reintegres': ArticleRetourne.objects.filter(statut_retour='reintegre_stock').count(),
+        'total_traites': ArticleRetourne.objects.exclude(statut_retour='en_attente').count(),
+        'valeur_total_en_attente': ArticleRetourne.objects.filter(
+            statut_retour='en_attente'
+        ).aggregate(
+            total=Sum('quantite_retournee') * Sum('prix_unitaire_origine')
+        )['total'] or 0
+    }
+
+    # Pagination
+    paginator = Paginator(articles_retournes, 25)
+    page_number = request.GET.get('page')
+    page_obj = paginator.get_page(page_number)
+
+    context = {
+        'page_obj': page_obj,
+        'search_query': search_query,
+        'statut_filter': statut_filter,
+        'stats': stats,
+        'page_title': 'Service - Gestion des Articles Retournés',
+        'page_subtitle': 'Articles retournés lors des livraisons partielles',
+        'active_tab': 'service',
+        'breadcrumbs': [
+            {'name': 'Accueil', 'url': 'Superpreparation:home'},
+            {'name': 'Service', 'url': None},
+            {'name': 'Articles Retournés', 'url': None}
+        ]
+    }
+
+    return render(request, 'Superpreparation/service/articles_retournes/liste.html', context)
+
+
+@superviseur_preparation_required
+def detail_article_retourne_service(request, retour_id):
+    """Détail d'un article retourné - Version Superpreparation"""
+  
+
+    article_retourne = get_object_or_404(
+        ArticleRetourne.objects.select_related(
+            'commande', 'article', 'variante', 'operateur_retour', 'operateur_traitement'
+        ),
+        id=retour_id
+    )
+
+    context = {
+        'article_retourne': article_retourne,
+        'page_title': f'Service - Détail Retour #{article_retourne.id}',
+        'page_subtitle': f'Article: {article_retourne.article.nom}',
+        'active_tab': 'service',
+        'breadcrumbs': [
+            {'name': 'Accueil', 'url': 'Superpreparation:home'},
+            {'name': 'Service', 'url': None},
+            {'name': 'Articles Retournés', 'url': 'Superpreparation:service_liste_articles_retournes'},
+            {'name': f'Retour #{article_retourne.id}', 'url': None}
+        ]
+    }
+
+    return render(request, 'Superpreparation/service/articles_retournes/detail.html', context)
+
+
+@require_POST
+def traiter_article_retourne_service(request, retour_id):
+    """Traiter un article retourné (réintégrer, marquer défectueux, etc.) - Version Superpreparation"""
+    
+
+    try:
+        article_retourne = get_object_or_404(ArticleRetourne, id=retour_id)
+
+        if article_retourne.statut_retour != 'en_attente':
+            return JsonResponse({
+                'success': False,
+                'error': 'Cet article a déjà été traité.'
+            })
+
+        action = request.POST.get('action')
+        commentaire = request.POST.get('commentaire', '').strip()
+
+        # Récupérer l'opérateur de manière sécurisée
+        try:
+            operateur = request.user.profil_operateur
+        except AttributeError:
+            # Fallback si pas de profil opérateur
+            try:
+                operateur = Operateur.objects.get(user=request.user, actif=True)
+            except Operateur.DoesNotExist:
+                operateur = None
+
+        if action == 'reintegrer_stock':
+            if article_retourne.peut_etre_reintegre():
+                if article_retourne.reintegrer_stock(operateur, commentaire):
+                    return JsonResponse({
+                        'success': True,
+                        'message': f'Article réintégré en stock avec succès. +{article_retourne.quantite_retournee} en stock.',
+                        'redirect': True,
+                        'redirect_url': request.META.get('HTTP_REFERER', '/superpreparation/service/articles-retournes/')
+                    })
+                else:
+                    return JsonResponse({
+                        'success': False,
+                        'error': 'Erreur lors de la réintégration en stock.'
+                    })
+            else:
+                return JsonResponse({
+                    'success': False,
+                    'error': 'Cet article ne peut pas être réintégré (variante inactive ou manquante).'
+                })
+
+        elif action == 'marquer_defectueux':
+            article_retourne.statut_retour = 'defectueux'
+            article_retourne.date_traitement = timezone.now()
+            article_retourne.operateur_traitement = operateur
+            article_retourne.commentaire_traitement = commentaire or 'Marqué comme défectueux'
+            article_retourne.save()
+
+            return JsonResponse({
+                'success': True,
+                'message': 'Article marqué comme défectueux.',
+                'redirect': True,
+                'redirect_url': request.META.get('HTTP_REFERER', '/superpreparation/service/articles-retournes/')
+            })
+
+        elif action == 'marquer_traite':
+            article_retourne.statut_retour = 'traite'
+            article_retourne.date_traitement = timezone.now()
+            article_retourne.operateur_traitement = operateur
+            article_retourne.commentaire_traitement = commentaire or 'Traité manuellement'
+            article_retourne.save()
+
+            return JsonResponse({
+                'success': True,
+                'message': 'Article marqué comme traité.',
+                'redirect': True,
+                'redirect_url': request.META.get('HTTP_REFERER', '/superpreparation/service/articles-retournes/')
+            })
+
+        else:
+            return JsonResponse({
+                'success': False,
+                'error': 'Action non reconnue.'
+            })
+
+    except Exception as e:
+        return JsonResponse({
+            'success': False,
+            'error': f'Erreur lors du traitement: {str(e)}'
+        })
+
+
+@superviseur_preparation_required
+@require_POST
+def reintegrer_automatique_service(request):
+    """Réintégrer automatiquement tous les articles retournés éligibles - Version Superpreparation"""
+    
+
+    try:
+        # Récupérer l'opérateur de manière sécurisée
+        try:
+            operateur = request.user.profil_operateur
+        except AttributeError:
+            # Fallback si pas de profil opérateur
+            try:
+                operateur = Operateur.objects.get(user=request.user, actif=True)
+            except Operateur.DoesNotExist:
+                operateur = None
+
+        # Récupérer tous les articles retournés éligibles à la réintégration
+        articles_eligibles = ArticleRetourne.objects.filter(
+            statut_retour='en_attente',
+            variante__isnull=False,
+            variante__actif=True
+        )
+
+        total_reintegres = 0
+        erreurs = []
+
+        for article_retourne in articles_eligibles:
+            try:
+                if article_retourne.reintegrer_stock(
+                    operateur,
+                    "Réintégration automatique en lot (Service Superpreparation)"
+                ):
+                    total_reintegres += 1
+            except Exception as e:
+                erreurs.append(f"Article {article_retourne.id}: {str(e)}")
+
+        if total_reintegres > 0:
+            messages.success(
+                request,
+                f"{total_reintegres} article(s) réintégré(s) automatiquement en stock."
+            )
+
+        if erreurs:
+            messages.warning(
+                request,
+                f"Quelques erreurs sont survenues: {', '.join(erreurs[:3])}"
+            )
+
+        return JsonResponse({
+            'success': True,
+            'message': f'{total_reintegres} article(s) réintégré(s) automatiquement.',
+            'total_reintegres': total_reintegres,
+            'erreurs': erreurs,
+            'redirect': True,
+            'redirect_url': request.META.get('HTTP_REFERER', '/superpreparation/service/articles-retournes/')
+        })
+
+    except Exception as e:
+        return JsonResponse({
+            'success': False,
+            'error': f'Erreur lors de la réintégration automatique: {str(e)}'
+        })
+
+
+@superviseur_preparation_required
+def statistiques_retours_service(request):
+    """Page de statistiques des retours - Version Superpreparation"""
+  
+
+    # Statistiques générales
+    from django.db.models import Sum, Avg
+    from datetime import datetime, timedelta
+
+    today = datetime.now().date()
+    week_ago = today - timedelta(days=7)
+    month_ago = today - timedelta(days=30)
+
+    stats_generales = {
+        'total_retours': ArticleRetourne.objects.count(),
+        'retours_semaine': ArticleRetourne.objects.filter(date_retour__date__gte=week_ago).count(),
+        'retours_mois': ArticleRetourne.objects.filter(date_retour__date__gte=month_ago).count(),
+        'valeur_totale_retours': ArticleRetourne.objects.aggregate(
+            total=Sum('quantite_retournee') * Sum('prix_unitaire_origine')
+        )['total'] or 0,
+        'taux_reintegration': 0  # À calculer
+    }
+
+    # Calculer le taux de réintégration
+    total_traites = ArticleRetourne.objects.exclude(statut_retour='en_attente').count()
+    total_reintegres = ArticleRetourne.objects.filter(statut_retour='reintegre_stock').count()
+    if total_traites > 0:
+        stats_generales['taux_reintegration'] = round((total_reintegres / total_traites) * 100, 2)
+
+    # Top articles retournés
+    top_articles = ArticleRetourne.objects.values(
+        'article__nom'
+    ).annotate(
+        total_retours=Count('id'),
+        total_quantite=Sum('quantite_retournee')
+    ).order_by('-total_retours')[:10]
+
+    context = {
+        'stats_generales': stats_generales,
+        'top_articles': top_articles,
+        'page_title': 'Service - Statistiques des Retours',
+        'page_subtitle': 'Analyse des articles retournés',
+        'active_tab': 'service',
+        'breadcrumbs': [
+            {'name': 'Accueil', 'url': 'Superpreparation:home'},
+            {'name': 'Service', 'url': None},
+            {'name': 'Statistiques Retours', 'url': None}
+        ]
+    }
+
+    return render(request, 'Superpreparation/service/articles_retournes/statistiques.html', context)
+
+
+@superviseur_preparation_required
+def api_articles_retournes_modal(request):
+    """API pour récupérer les articles retournés à afficher dans la modale"""
+    try:
+        # Récupérer les articles retournés en attente uniquement
+        articles_retournes = ArticleRetourne.objects.filter(
+            statut_retour='en_attente'
+        ).select_related(
+            'commande', 'commande__client', 'article', 'variante', 'operateur_retour'
+        ).prefetch_related(
+            'variante__couleur', 'variante__pointure'
+        ).order_by('-date_retour')
+
+        # Limiter à 50 pour éviter une surcharge
+        articles_retournes = articles_retournes[:50]
+
+        articles_data = []
+        for article in articles_retournes:
+            try:
+                # Construire les données avec vérifications et valeurs par défaut
+                has_variante = article.variante is not None
+
+                article_data = {
+                    'id': article.id,
+                    'article_nom': article.article.nom if article.article else 'N/A',
+                    'article_reference': getattr(article.article, 'reference', '') if article.article else '',
+                    'variante_info': {
+                        'couleur': article.variante.couleur.nom if has_variante and hasattr(article.variante, 'couleur') and article.variante.couleur else '',
+                        'pointure': article.variante.pointure.pointure if has_variante and hasattr(article.variante, 'pointure') and article.variante.pointure else '',
+                        'reference_variante': getattr(article.variante, 'reference_variante', '') if has_variante else '',
+                        'stock_disponible': getattr(article.variante, 'qte_disponible', 0) if has_variante else 0,
+                        'has_variante': has_variante,
+                    },
+                    'commande_info': {
+                        'id_yz': getattr(article.commande, 'id_yz', '') if article.commande else '',
+                        'num_cmd': getattr(article.commande, 'num_cmd', '') if article.commande else '',
+                        'client_nom': f"{article.commande.client.prenom} {article.commande.client.nom}" if article.commande and article.commande.client else 'N/A',
+                    },
+                    'quantite_retournee': article.quantite_retournee or 0,
+                    'prix_unitaire': float(article.prix_unitaire_origine) if article.prix_unitaire_origine else 0.0,
+                    'date_retour': article.date_retour.strftime('%d/%m/%Y %H:%M') if article.date_retour else '',
+                    'raison_retour': article.raison_retour or 'Non spécifiée',
+                    'operateur_retour': f"{article.operateur_retour.prenom} {article.operateur_retour.nom}" if article.operateur_retour else 'N/A',
+                    'peut_etre_reintegre': article.peut_etre_reintegre(),
+                    'statut': article.get_statut_retour_display(),
+                }
+                articles_data.append(article_data)
+            except Exception as inner_e:
+                # Log l'erreur mais continuer avec les autres articles
+                print(f"Erreur lors du traitement de l'article {article.id}: {inner_e}")
+                continue
+
+        return JsonResponse({
+            'success': True,
+            'articles': articles_data,
+            'total': len(articles_data)
+        })
+
+    except Exception as e:
+        return JsonResponse({
+            'success': False,
+            'error': f'Erreur lors du chargement des articles: {str(e)}'
+        })

--- a/Superpreparation/urls.py
+++ b/Superpreparation/urls.py
@@ -1,6 +1,7 @@
 from django.urls import path
 from django.shortcuts import redirect
 from . import views
+from . import service_views
 from .barre_recherche_globale import views as search_views
 
 app_name = 'Superpreparation'
@@ -166,7 +167,16 @@ urlpatterns = [
     path('gestion-articles/genres/modifier/<int:genre_id>/', views.modifier_genre, name='modifier_genre'),
     path('gestion-articles/genres/supprimer/<int:genre_id>/', views.supprimer_genre, name='supprimer_genre'),
 
+    # === NOUVELLES URLs : SERVICE - GESTION DES ARTICLES RETOURNÉS ===
+    # Pages principales du service
+    path('service/articles-retournes/', service_views.liste_articles_retournes_service, name='service_liste_articles_retournes'),
+    path('service/articles-retournes/<int:retour_id>/', service_views.detail_article_retourne_service, name='service_detail_article_retourne'),
+    path('service/articles-retournes/statistiques/', service_views.statistiques_retours_service, name='service_statistiques_retours'),
 
-   
+    # APIs pour le traitement des articles retournés
+    path('service/api/traiter-article-retourne/<int:retour_id>/', service_views.traiter_article_retourne_service, name='service_traiter_article_retourne'),
+    path('service/api/reintegrer-automatique/', service_views.reintegrer_automatique_service, name='service_reintegrer_automatique'),
+    path('service/api/articles-retournes-modal/', service_views.api_articles_retournes_modal, name='service_api_articles_retournes_modal'),
+
 
 ]

--- a/Superpreparation/views.py
+++ b/Superpreparation/views.py
@@ -802,6 +802,17 @@ def commandes_livrees_partiellement(request):
                 commande.commande_renvoi_id = commande.commande_renvoi.id
                 commande.commande_renvoi_num = commande.commande_renvoi.num_cmd
                 commande.commande_renvoi_id_yz = commande.commande_renvoi.id_yz
+
+    # Récupérer les statistiques des articles retournés à traiter
+    from commande.models import ArticleRetourne
+
+    articles_retournes_stats = {
+        'total_en_attente': ArticleRetourne.objects.filter(statut_retour='en_attente').count(),
+        'total_reintegres': ArticleRetourne.objects.filter(statut_retour='reintegre_stock').count(),
+        'total_defectueux': ArticleRetourne.objects.filter(statut_retour='defectueux').count(),
+        'total_traites': ArticleRetourne.objects.exclude(statut_retour='en_attente').count(),
+    }
+
     context = {
         'page_title': 'Suivi - Commandes Livrées Partiellement',
         'page_subtitle': f'Suivi en temps réel de {len(commandes_livrees_partiellement)} commande(s) livrées partiellement',
@@ -810,9 +821,11 @@ def commandes_livrees_partiellement(request):
         'commandes_count': len(commandes_livrees_partiellement),
         'active_tab': 'livrees_partiellement',
         'is_readonly': True,
-        'is_tracking_page': True
+        'is_tracking_page': True,
+        'articles_retournes_stats': articles_retournes_stats,  # Ajout des stats
     }
     return render(request, 'Superpreparation/commandes_livrees_partiellement.html', context)
+
 @superviseur_preparation_required
 def commandes_retournees(request):
     """Page de suivi (lecture seule) des commandes retournées"""

--- a/templates/Superpreparation/commandes_livrees_partiellement.html
+++ b/templates/Superpreparation/commandes_livrees_partiellement.html
@@ -596,6 +596,38 @@
     .compact-page #cmdTable th:nth-child(8), .compact-page #cmdTable td:nth-child(8) { width: 100px; min-width: 100px; } /* Total */
     .compact-page #cmdTable th:nth-child(9), .compact-page #cmdTable td:nth-child(9) { width: 100px; min-width: 100px; } /* État */
     .compact-page #cmdTable th:nth-child(10), .compact-page #cmdTable td:nth-child(10) { width: 110px; min-width: 110px; }/* Panier */
+    .compact-page #cmdTable th:nth-child(11), .compact-page #cmdTable td:nth-child(11) { width: 100px; min-width: 100px; }/* Actions */
+
+    /* Styles pour le bouton Articles retournés */
+    .articles-button {
+        position: relative;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        transition: all 0.2s ease-in-out;
+    }
+
+    .articles-button:hover {
+        transform: translateY(-1px);
+        box-shadow: 0 4px 12px rgba(234, 88, 12, 0.15);
+    }
+
+    .articles-badge {
+        animation: bounce 2s infinite;
+    }
+
+    .articles-badge-pulse {
+        animation: pulse 2s infinite;
+    }
+
+    @media (max-width: 640px) {
+        .articles-button span:not(.articles-badge) {
+            display: none;
+        }
+        .articles-button i {
+            margin-right: 0 !important;
+        }
+    }
 </style>
 {% endblock %}
 
@@ -629,7 +661,7 @@
     </div>
 
     <!-- Statistiques -->
-    <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
+    <div class="grid grid-cols-1 md:grid-cols-4 gap-6 mb-8">
         <!-- Total des commandes -->
         <div class="stats-card animate-slideInUp" style="animation-delay: 0.1s;">
                 <div class="flex items-center">
@@ -663,8 +695,22 @@
                         <i class="fas fa-exclamation-triangle text-2xl"></i>
                     </div>
                     <div class="ml-4">
-                    <p class="text-sm font-medium text-gray-600">Urgentes</p>
+                    <p class="text-sm font-medium text-gray-600">Nombres d'articles defecteux </p>
                     <p class="text-3xl font-bold text-gray-900">{{ stats.commandes_urgentes|default:0 }}</p>
+                </div>
+            </div>
+        </div>
+
+        <!-- Articles retournés à traiter -->
+        <div class="stats-card animate-slideInUp cursor-pointer hover:shadow-lg transition-all duration-200" style="animation-delay: 0.4s;" onclick="ouvrirModaleArticlesRetournes()">
+                <div class="flex items-center">
+                <div class="stats-icon bg-orange-500">
+                        <i class="fas fa-undo text-2xl"></i>
+                    </div>
+                    <div class="ml-4">
+                    <p class="text-sm font-medium text-gray-600">Articles à Traiter</p>
+                    <p class="text-3xl font-bold text-orange-600">{{ articles_retournes_stats.total_en_attente|default:0 }}</p>
+                    <p class="text-xs text-gray-500">Cliquer pour voir</p>
                 </div>
             </div>
         </div>
@@ -737,6 +783,7 @@
                         <th class="table-cell text-left text-xs font-medium text-white uppercase tracking-wider">Total</th>
                         <th class="table-cell text-left text-xs font-medium text-white uppercase tracking-wider">État</th>
                         <th class="table-cell text-center text-xs font-medium text-white uppercase tracking-wider">Panier</th>
+                        <th class="table-cell text-center text-xs font-medium text-white uppercase tracking-wider">Actions</th>
                     </tr>
                 </thead>
                 <tbody class="bg-white divide-y divide-gray-200">
@@ -823,18 +870,35 @@
                             </td>
                             
                             <td class="table-cell whitespace-nowrap text-center">
-                                <a href="{% url 'Superpreparation:detail_prepa' commande.pk %}" 
+                                <a href="{% url 'Superpreparation:detail_prepa' commande.pk %}"
                                    class="action-button"
                                    title="Voir le panier de cette commande">
-                                    <i class="fas fa-shopping-cart"></i> 
+                                    <i class="fas fa-shopping-cart"></i>
                                     {{ commande.paniers.count }} article{{ commande.paniers.count|pluralize }}
                                 </a>
+                            </td>
+
+                            <!-- Nouvelle colonne Actions -->
+                            <td class="table-cell whitespace-nowrap text-center">
+                                <div class="flex justify-center space-x-2">
+                                    <button onclick="ouvrirModaleArticlesRetournes()"
+                                            class="action-button articles-button relative bg-orange-50 text-orange-600 hover:bg-orange-100 border border-orange-200 hover:border-orange-300 transition-all duration-200"
+                                            title="Voir les articles retournés à traiter ({{ articles_retournes_stats.total_en_attente }} en attente)">
+                                        <i class="fas fa-undo mr-1"></i>
+                                        <span class="hidden sm:inline">Articles</span>
+                                        {% if articles_retournes_stats.total_en_attente > 0 %}
+                                        <span class="articles-badge absolute -top-2 -right-2 inline-flex items-center justify-center px-2 py-1 text-xs font-bold leading-none text-white bg-red-600 rounded-full min-w-[20px] h-5">
+                                            {{ articles_retournes_stats.total_en_attente }}
+                                        </span>
+                                        {% endif %}
+                                    </button>
+                                </div>
                             </td>
                         </tr>
                         {% endfor %}
                     {% else %}
                         <tr>
-                            <td colspan="10" class="table-cell whitespace-nowrap text-center">
+                            <td colspan="11" class="table-cell whitespace-nowrap text-center">
                                 <div class="empty-state">
                                     <div class="empty-state-icon">
                                         <i class="fas fa-truck"></i>
@@ -941,6 +1005,39 @@ document.addEventListener('DOMContentLoaded', function() {
 });
 </script>
 
+<!-- Modale des Articles Retournés à Traiter -->
+<div id="modaleArticlesRetournes" class="fixed inset-0 bg-gray-600 bg-opacity-50 overflow-y-auto h-full w-full hidden z-50">
+    <div class="relative top-10 mx-auto p-6 border w-full max-w-6xl shadow-lg rounded-lg bg-white">
+        <div class="flex justify-between items-start mb-6">
+            <div>
+                <h3 class="text-xl font-bold text-gray-900 flex items-center">
+                    <i class="fas fa-undo mr-2 text-orange-600"></i>
+                    Service - Articles Retournés à Traiter
+                </h3>
+                <p class="text-sm text-gray-600 mt-1">Articles retournés lors de livraisons partielles en attente de traitement</p>
+            </div>
+            <button onclick="fermerModaleArticlesRetournes()" class="text-gray-400 hover:text-gray-600 transition-colors">
+                <i class="fas fa-times text-2xl"></i>
+            </button>
+        </div>
+
+        <!-- Contenu de la modale -->
+        <div id="contenuArticlesRetournes" class="space-y-4">
+            <div class="text-center py-8">
+                <i class="fas fa-spinner fa-spin text-3xl text-blue-600 mb-4"></i>
+                <p class="text-gray-600">Chargement des articles retournés...</p>
+            </div>
+        </div>
+
+        <!-- Actions -->
+        <div class="flex justify-between items-center mt-6 pt-4 border-t border-gray-200">
+            <button onclick="fermerModaleArticlesRetournes()" class="px-4 py-2 bg-gray-500 text-white rounded-md hover:bg-gray-600 transition-colors">
+                <i class="fas fa-times mr-2"></i>Fermer
+            </button>
+        </div>
+    </div>
+</div>
+
 {% endblock %}
 
 {% block extra_js %}
@@ -951,6 +1048,300 @@ document.addEventListener('DOMContentLoaded', function() {
 document.addEventListener('DOMContentLoaded', function() {
     if (typeof initSuiviCommandesSearch === 'function') {
         initSuiviCommandesSearch('livrees_partiellement');
+    }
+});
+
+// === GESTION DES ARTICLES RETOURNÉS ===
+
+function ouvrirModaleArticlesRetournes() {
+    console.log('Ouverture de la modale des articles retournés');
+    document.getElementById('modaleArticlesRetournes').classList.remove('hidden');
+    chargerArticlesRetournes();
+}
+
+function fermerModaleArticlesRetournes() {
+    console.log('Fermeture de la modale des articles retournés');
+    document.getElementById('modaleArticlesRetournes').classList.add('hidden');
+}
+
+function chargerArticlesRetournes() {
+    console.log('Chargement des articles retournés...');
+    const contenu = document.getElementById('contenuArticlesRetournes');
+
+    // Afficher le spinner
+    contenu.innerHTML = `
+        <div class="text-center py-8">
+            <i class="fas fa-spinner fa-spin text-3xl text-blue-600 mb-4"></i>
+            <p class="text-gray-600">Chargement des articles retournés...</p>
+        </div>
+    `;
+
+    fetch('{% url "Superpreparation:service_api_articles_retournes_modal" %}', {
+            headers: {
+                'X-Requested-With': 'XMLHttpRequest',
+                'Content-Type': 'application/json',
+                'X-CSRFToken': '{{ csrf_token }}'
+            }
+        })
+        .then(response => response.json())
+        .then(data => {
+            if (data.success) {
+                afficherArticlesRetournes(data.articles);
+            } else {
+                contenu.innerHTML = `
+                    <div class="text-center py-8 text-red-600">
+                        <i class="fas fa-exclamation-triangle text-3xl mb-4"></i>
+                        <p>Erreur: ${data.error}</p>
+                    </div>
+                `;
+            }
+        })
+        .catch(error => {
+            console.error('Erreur:', error);
+            contenu.innerHTML = `
+                <div class="text-center py-8 text-red-600">
+                    <i class="fas fa-exclamation-triangle text-3xl mb-4"></i>
+                    <p>Erreur de réseau lors du chargement</p>
+                </div>
+            `;
+        });
+}
+
+function afficherArticlesRetournes(articles) {
+    const contenu = document.getElementById('contenuArticlesRetournes');
+
+    if (articles.length === 0) {
+        contenu.innerHTML = `
+            <div class="text-center py-8">
+                <i class="fas fa-check-circle text-3xl text-green-600 mb-4"></i>
+                <p class="text-gray-600">Aucun article retourné en attente de traitement</p>
+            </div>
+        `;
+        return;
+    }
+
+    let html = `
+        <div class="mb-4 p-3 bg-blue-50 rounded-lg">
+            <div class="flex items-center justify-between">
+                <span class="text-sm text-blue-800">
+                    <i class="fas fa-info-circle mr-2"></i>
+                    ${articles.length} article(s) retourné(s) en attente de traitement
+                </span>
+                <div class="text-xs text-blue-600">
+                    Affichage des ${Math.min(articles.length, 50)} premiers résultats
+                </div>
+            </div>
+        </div>
+
+        <div class="overflow-x-auto">
+            <table class="min-w-full divide-y divide-gray-200">
+                <thead class="bg-gray-50">
+                    <tr>
+                        <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Article & Variante</th>
+                        <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Commande</th>
+                        <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Client</th>
+                        <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Quantité</th>
+                        <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Date Retour</th>
+                        <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Raison</th>
+                        <th class="px-4 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
+                    </tr>
+                </thead>
+                <tbody class="bg-white divide-y divide-gray-200">
+    `;
+
+    articles.forEach(article => {
+        const canReintegrate = article.peut_etre_reintegre;
+
+        html += `
+            <tr class="hover:bg-gray-50">
+                <td class="px-4 py-4 whitespace-nowrap">
+                    <div class="bg-gray-50 p-3 rounded-lg border border-gray-200">
+                        <div class="text-sm font-medium text-gray-900 mb-1">${article.article_nom}</div>
+                        <div class="text-xs text-gray-500 mb-2">Réf: ${article.article_reference}</div>
+                        ${article.variante_info.has_variante ? `
+                            <div class="border-t border-gray-200 pt-2 mt-2">
+                                <div class="text-xs font-medium text-gray-700 mb-1">Variante associée :</div>
+                                <div class="space-y-1">
+                                    ${article.variante_info.reference_variante ? `
+                                        <div class="text-xs text-gray-600">
+                                            <i class="fas fa-barcode mr-1"></i>Réf: ${article.variante_info.reference_variante}
+                                        </div>
+                                    ` : ''}
+                                    <div class="flex flex-wrap gap-1">
+                                        ${article.variante_info.couleur ? `
+                                            <span class="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
+                                                <i class="fas fa-palette mr-1"></i>${article.variante_info.couleur}
+                                            </span>
+                                        ` : ''}
+                                        ${article.variante_info.pointure ? `
+                                            <span class="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-green-100 text-green-800">
+                                                <i class="fas fa-ruler mr-1"></i>Taille ${article.variante_info.pointure}
+                                            </span>
+                                        ` : ''}
+                                        <span class="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium ${article.variante_info.stock_disponible > 0 ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800'}">
+                                            <i class="fas fa-boxes mr-1"></i>Stock: ${article.variante_info.stock_disponible}
+                                        </span>
+                                    </div>
+                                </div>
+                            </div>
+                        ` : `
+                            <div class="border-t border-gray-200 pt-2 mt-2">
+                                <div class="text-xs text-red-400 italic flex items-center">
+                                    <i class="fas fa-exclamation-triangle mr-1"></i>
+                                    Aucune variante associée
+                                </div>
+                            </div>
+                        `}
+                    </div>
+                </td>
+                <td class="px-4 py-4 whitespace-nowrap">
+                    <div class="text-sm font-medium text-gray-900">${article.commande_info.id_yz}</div>
+                    <div class="text-xs text-gray-500">${article.commande_info.num_cmd}</div>
+                </td>
+                <td class="px-4 py-4 whitespace-nowrap">
+                    <div class="text-sm text-gray-900">${article.commande_info.client_nom}</div>
+                </td>
+                <td class="px-4 py-4 whitespace-nowrap">
+                    <div class="text-sm font-bold text-orange-600">${article.quantite_retournee}x</div>
+                    <div class="text-xs text-gray-500">${article.prix_unitaire} DH</div>
+                </td>
+                <td class="px-4 py-4 whitespace-nowrap">
+                    <div class="text-sm text-gray-900">${article.date_retour}</div>
+                </td>
+                <td class="px-4 py-4">
+                    <div class="text-sm text-gray-900 max-w-xs truncate" title="${article.raison_retour}">
+                        ${article.raison_retour}
+                    </div>
+                </td>
+                <td class="px-4 py-4 whitespace-nowrap text-center">
+                    <div class="flex justify-center space-x-2">
+                        ${canReintegrate ? `
+                            <button onclick="traiterArticle(${article.id}, 'reintegrer_stock')"
+                                    class="text-green-600 hover:text-green-900 transition-colors"
+                                    title="Réintégrer en stock">
+                                <i class="fas fa-check-circle"></i>
+                            </button>
+                        ` : ''}
+                        <button onclick="traiterArticle(${article.id}, 'marquer_defectueux')"
+                                class="text-red-600 hover:text-red-900 transition-colors"
+                                title="Marquer défectueux">
+                            <i class="fas fa-times-circle"></i>
+                        </button>
+                        <button onclick="traiterArticle(${article.id}, 'marquer_traite')"
+                                class="text-blue-600 hover:text-blue-900 transition-colors"
+                                title="Marquer traité">
+                            <i class="fas fa-check"></i>
+                        </button>
+                    </div>
+                </td>
+            </tr>
+        `;
+    });
+
+    html += `
+                </tbody>
+            </table>
+        </div>
+    `;
+
+    contenu.innerHTML = html;
+}
+
+function traiterArticle(articleId, action) {
+    const actions = {
+        'reintegrer_stock': 'réintégrer en stock',
+        'marquer_defectueux': 'marquer comme défectueux',
+        'marquer_traite': 'marquer comme traité'
+    };
+
+    if (!confirm(`Êtes-vous sûr de vouloir ${actions[action]} cet article ?`)) {
+        return;
+    }
+
+    const formData = new FormData();
+    formData.append('action', action);
+    formData.append('commentaire', `Traitement via Superpreparation - ${new Date().toLocaleString()}`);
+
+    const url = `{% url "Superpreparation:service_traiter_article_retourne" 0 %}`.replace('0', articleId);
+    console.log('Fetching URL:', url);
+
+    fetch(url, {
+        method: 'POST',
+        body: formData,
+        headers: {
+            'X-Requested-With': 'XMLHttpRequest',
+            'X-CSRFToken': '{{ csrf_token }}'
+        }
+    })
+    .then(response => {
+        console.log('Response status:', response.status);
+        console.log('Response headers:', response.headers.get('content-type'));
+        if (!response.ok) {
+            throw new Error(`HTTP error! status: ${response.status}`);
+        }
+        return response.json();
+    })
+    .then(data => {
+        if (data.success) {
+            showToast(data.message, 'success');
+            // Recharger les articles
+            chargerArticlesRetournes();
+            // Mettre à jour le compteur dans le card
+            location.reload();
+        } else {
+            showToast(`Erreur: ${data.error}`, 'error');
+        }
+    })
+    .catch(error => {
+        console.error('Erreur:', error);
+        showToast('Erreur de réseau lors du traitement', 'error');
+    });
+}
+
+function reintegrerTousLesArticles() {
+    if (!confirm('Êtes-vous sûr de vouloir réintégrer automatiquement tous les articles éligibles ?')) {
+        return;
+    }
+
+    fetch('{% url "Superpreparation:service_reintegrer_automatique" %}', {
+        method: 'POST',
+        headers: {
+            'X-CSRFToken': document.querySelector('[name=csrfmiddlewaretoken]').value
+        }
+    })
+    .then(response => response.json())
+    .then(data => {
+        if (data.success) {
+            showToast(data.message, 'success');
+            // Recharger les articles
+            chargerArticlesRetournes();
+            // Recharger la page pour mettre à jour les statistiques
+            setTimeout(() => location.reload(), 1500);
+        } else {
+            showToast(`Erreur: ${data.error}`, 'error');
+        }
+    })
+    .catch(error => {
+        console.error('Erreur:', error);
+        showToast('Erreur de réseau lors de la réintégration automatique', 'error');
+    });
+}
+
+// Fermer la modale en cliquant en dehors
+document.addEventListener('click', function(e) {
+    const modale = document.getElementById('modaleArticlesRetournes');
+    if (e.target === modale) {
+        fermerModaleArticlesRetournes();
+    }
+});
+
+// Fermer avec Échap
+document.addEventListener('keydown', function(e) {
+    if (e.key === 'Escape') {
+        const modale = document.getElementById('modaleArticlesRetournes');
+        if (!modale.classList.contains('hidden')) {
+            fermerModaleArticlesRetournes();
+        }
     }
 });
 </script>


### PR DESCRIPTION
Ajout d'un nouveau fichier service_views.py pour la gestion des articles retournés (listage, traitement, statistiques, API modale). Intégration des URLs associées dans Superpreparation/urls.py. Ajout de l'affichage des statistiques d'articles retournés dans la vue et le template des commandes livrées partiellement, ainsi qu'une modale interactive pour leur traitement rapide.